### PR TITLE
einops 0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "einops" %}
-{% set version = "0.6.0" %}
+{% set version = "0.8.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,20 +7,20 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6f6c78739316a2e3ccbce8052310497e69da092935e4173f2e76ec4e3a336a35
+  sha256: de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84
 
 build:
-  noarch: python
+  skip: true # [ py<310 ]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - hatchling >=1.10.0
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,15 +32,15 @@ test:
     - pip
 
 about:
-  home: https://github.com/arogozhnikov/einops
+  home: https://einops.rocks/
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: A new flavour of deep learning operations.
+  summary: Flexible and powerful tensor operations for readable and reliable code.
   description: |
     Flexible and powerful tensor operations for readable and reliable code.
     Supports numpy, pytorch, tensorflow, and others.
-  doc_url: https://github.com/arogozhnikov/einops
+  doc_url: https://einops.rocks/
   dev_url: https://github.com/arogozhnikov/einops
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: de5d960a7a761225532e0f1959e5315ebeafc0cd43394732f103ca44b9837e84
 
 build:
-  skip: true # [ py<310 ]
+  skip: true # [py<310]
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -28,8 +28,11 @@ test:
     - einops.layers
   commands:
     - pip check
+    - python -m einops.tests.run_tests numpy
   requires:
     - pip
+    - pytest
+    - numpy
 
 about:
   home: https://einops.rocks/


### PR DESCRIPTION
einops 0.8.1

**Destination channel:** defaults

Note: Not yet pinned in aggregate

### Links

- [PKG-11453](https://anaconda.atlassian.net/browse/PKG-11453) 
- Upstream repo: https://github.com/arogozhnikov/einops
- conda-forge: https://github.com/conda-forge/einops-feedstock
- Release notes: https://github.com/arogozhnikov/einops/releases

### Explanation of changes:

- New recipe on the main channel. The whole recipe should be reviewed, though it is slightly based off of the conda-forge recipe.
- Part of vllm dependency chain


[PKG-11453]: https://anaconda.atlassian.net/browse/PKG-11453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ